### PR TITLE
Remove pytest-runner dependency from host requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ test:
 
 about:
   home: https://github.com/cylc/cylc-uiserver
-  license: GPL-3.0
+  license: GPL-3.0-only
   license_family: GPL
   license_file: COPYING
   summary: Cylc UI Server

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 796af6b1fb74b63cd87c1be304e56f7cc618d5264fc0b8dd974050271f673be8
 
 build:
-  number: 2
+  number: 3
   # cylc-uiserver provides JupyterHub extensions and a small Jupyter Application. As JupyterHub
   # does not run on Windows, we skip the build for that platform here
   skip: true  # [py<37 or not linux]
@@ -21,10 +21,6 @@ requirements:
   host:
     - python
     - pip
-    # TODO: build failed with pytest-runner only, because the setup.py of cylc-uiserver specifies this
-    # version of pytest-runner. Need to make pytest-runner a dependency only for python setup.py test
-    # and then remove this from requirements|host in the recipe
-    - pytest-runner ==4.4
   run:
     - python
     - cylc-flow ==8.0a2


### PR DESCRIPTION
Not for merging (don't want to change the builds in cylc). Just to see if this fix works for the #5 issue. If so, will leave the diff in the issue, and we can include it in the next release.