### PR TITLE
re-build post setuptools 61.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 4ee50d2130adff797494c47a12881bd2b6e3afcf610a2d214c180e13f77e5818
 
 build:
-  number: 1
+  number: 2
   noarch: python
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,6 +48,8 @@ outputs:
         - rx >=1.6,<2
 
     test:
+      files:
+        - tests/test_packaging.py
       imports:
         - cylc.flow
         - cylc.uiserver
@@ -55,6 +57,8 @@ outputs:
         - cylc version --long
         - cylc gui --help
         - command -v jupyter-cylc
+        - test_packaging.py ui
+        - test_packaging.py py.typed
 
   # UIS with the JupyterHub "base" package
   # (e.g. for sites that provide their own configurable HTTP proxy)
@@ -71,6 +75,8 @@ outputs:
         - {{ pin_subpackage(name + "-base", exact=True) }}
         - jupyterhub-base >=1.4.0,<1.5
     test:
+      files:
+        - tests/test_packaging.py
       imports:
         - cylc.flow
         - cylc.uiserver
@@ -80,6 +86,8 @@ outputs:
         - cylc hubapp --help
         - command -v jupyter-cylc
         - command -v jupyter-cylchubapp
+        - test_packaging.py ui
+        - test_packaging.py py.typed
 
   # UIS with the full JupyterHub package
   # (recommended)
@@ -96,6 +104,8 @@ outputs:
         - {{ pin_subpackage(name + "-base", exact=True) }}
         - jupyterhub >=1.4.0,<1.5
     test:
+      files:
+        - tests/test_packaging.py
       imports:
         - cylc.flow
         - cylc.uiserver
@@ -106,6 +116,8 @@ outputs:
         - configurable-http-proxy --help
         - command -v jupyter-cylc
         - command -v jupyter-cylchubapp
+        - test_packaging.py ui
+        - test_packaging.py py.typed
 
 about:
   home: https://github.com/cylc/cylc-uiserver

--- a/recipe/tests/test_packaging.py
+++ b/recipe/tests/test_packaging.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+from pathlib import Path
+import sys
+
+import cylc.uiserver
+
+
+def check_path(path):
+    package_path = Path(cylc.uiserver.__file__).parent / path
+    if not package_path.exists():
+        raise Exception(f'Path does not exist: {package_path}')
+    print(f'Path found in: {package_path}')
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        raise Exception('Only one argument accepted')
+    check_path(sys.argv[1])


### PR DESCRIPTION
If successful this will close #26

tldr; setuptools 61.0.0 was broken in a way that could cause the `MANIFEST.in` file to be ignored. When we released the cylc-uiserver it looks like this version was used during the release. This may be the cause of the missing UI files.

If so all we need to to is release a new build (there have been two subsequent setuptools releases since 61.0.0 apparently so a newer version should be used). I've attempted to add a packaging test.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
