### PR TITLE
remove upper-pin for jupyterhub

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 4ee50d2130adff797494c47a12881bd2b6e3afcf610a2d214c180e13f77e5818
 
 build:
-  number: 2
+  number: 3
   noarch: python
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,7 +73,7 @@ outputs:
         - pip
       run:
         - {{ pin_subpackage(name + "-base", exact=True) }}
-        - jupyterhub-base >=1.4.0,<1.5
+        - jupyterhub-base >=1.4.0
     test:
       files:
         - tests/test_packaging.py
@@ -102,7 +102,7 @@ outputs:
         - pip
       run:
         - {{ pin_subpackage(name + "-base", exact=True) }}
-        - jupyterhub >=1.4.0,<1.5
+        - jupyterhub >=1.4.0
     test:
       files:
         - tests/test_packaging.py


### PR DESCRIPTION
Remove upper pin for jupyterhub

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
